### PR TITLE
PayloadBuilder: Add category for quick actions

### DIFF
--- a/src/main/java/com/notnoop/apns/PayloadBuilder.java
+++ b/src/main/java/com/notnoop/apns/PayloadBuilder.java
@@ -88,6 +88,25 @@ public final class PayloadBuilder {
     }
 
     /**
+     * Sets the category of the notification for iOS8 notification
+     * actions.  See 13 minutes into "What's new in iOS Notifications"
+     *
+     * Passing {@code null} removes the category.
+     *
+     * @param category the name of the category supplied to the app
+     *              when receiving the notification
+     * @return  this
+     */
+    public PayloadBuilder category(final String category) {
+        if (category != null) {
+            aps.put("category", category);
+        } else {
+            aps.remove("category");
+        }
+        return this;
+    }
+
+    /**
      * Sets the notification badge to be displayed next to the
      * application icon.
      *


### PR DESCRIPTION
@chaitanyagupta : Please review.

 `category` has to be part of `aps` dictionary in push notification payload. 